### PR TITLE
Update silverFighters.json

### DIFF
--- a/IodemBot/Resources/silverFighters.json
+++ b/IodemBot/Resources/silverFighters.json
@@ -5,14 +5,14 @@
       "imgurl": "https://pbs.twimg.com/media/DxYLWDzWwAAAUEc.jpg",
       "movepool": 
 	  [
-	  "Cure Well",
+	  "Cure",
 	  "Ragnarök",
 	  "Odyssey",
 	  "Quake Sphere"
 	  ],
       "stats": {
-        "maxHP": 1500,
-        "maxPP": 300,
+        "maxHP": 1450,
+        "maxPP": 175,
         "Atk": 250,
         "Def": 60,
         "Spd": 70


### PR DESCRIPTION
On Isaac:
Cure Well -> Cure (should still heal around 200HP)
maxPP: 300 -> 175 (still +30PP compared to an in-game level 32 Isaac with 7 Djinn)
maxHP: 1500 -> 1450 (I know it's not significant at all but I felt like doing that)