### PR TITLE
A smol typo

### DIFF
--- a/IodemBot/Modules/GoldenSunMechanics/Effects/ReviveEffect.cs
+++ b/IodemBot/Modules/GoldenSunMechanics/Effects/ReviveEffect.cs
@@ -36,7 +36,7 @@ namespace IodemBot.Modules.GoldenSunMechanics
 
         public override string ToString()
         {
-            return $"Revive the target to {percentage}% of it's maximum Health.";
+            return $"Revive the target to {percentage}% of its maximum Health.";
         }
 
         protected override int InternalChooseBestTarget(List<ColossoFighter> targets)


### PR DESCRIPTION
"it's" -> "its" in "its maximum health".