### PR TITLE
Zol Gear, Sprites & various other updates

### DIFF
--- a/IodemBot/Resources/items.json
+++ b/IodemBot/Resources/items.json
@@ -3502,12 +3502,6 @@
         "IsArtifact": true,
         "AddStatsOnEquip": {
             "Def": 22
-        },
-        "AddElStatsOnEquip": {
-            "VenusRes": 15,
-            "VenusAtk": 15,
-            "JupiterAtk": 10,
-            "MarsRes": -10
         }
     },
     "Hover Greave": {
@@ -3705,7 +3699,7 @@
         },
         "AddElStatsOnEquip": {
             "MarsAtk": 30,
-            "MercuryAtk: -10
+            "MercuryAtk": -10
         }
     },
     "Crown of Glory": {

--- a/IodemBot/Resources/items.json
+++ b/IodemBot/Resources/items.json
@@ -702,15 +702,15 @@
             "EffectImages": [
                 {
                     "Id": "AddDamage",
-                    "args": [ "26" ]
+                    "args": [ "62" ]
                 },
                 {
                     "id": "HPDrain",
-                    "args": [ "80", "50" ]
+                    "args": [ "80", "30" ]
                 },
                 {
                     "id": "PPDrain",
-                    "args": [ "10", "50" ]
+                    "args": [ "10", "30" ]
                 }
             ]
         }
@@ -1319,7 +1319,7 @@
     "Fire Brand": {
         "Name": "Fire Brand",
         "Price": 23400,
-        "Icon": "<:Fire_Brand:570389787668905985>",
+        "Icon": "<:Fire_Brand:581966770470912031>",
         "ItemType": "LongSword",
         "IsEquippable": true,
         "IsArtifact": true,
@@ -1418,7 +1418,7 @@
     "Sword of Dusk": {
         "Name": "Sword of Dusk",
         "Price": 11500,
-        "Icon": "<:Sword_Of_Dusk:578173574355877889>",
+        "Icon": "<:Sword_Of_Dusk:581966887429079054>",
         "ItemType": "LongSword",
         "IsEquippable": true,
         "IsArtifact": true,
@@ -2339,7 +2339,7 @@
     "Verdant Sword": {
         "Name": "Verdant Sword",
         "Price": 18000,
-        "Icon": "<:Verdant_Sword:578173680937467924>",
+        "Icon": "<:Verdant_Sword:581967321351061504>",
         "ItemType": "LightBlade",
         "IsEquippable": true,
         "IsArtifact": true,
@@ -2944,11 +2944,14 @@
             "Def": 38,
             "MaxPP": 12
         },
-        "AddElStatsOnEquip": {
-            "VenusAtk": 15,
-            "VenusRes": 25,
-            "JupiterAtk": 15,
-            "JupiterRes": 25
+        "GrantsUnleash": true,
+        "Unleash": {
+            "effectImages": [
+                {
+                    "id": "Condition",
+                    "args": [ "Delusion", "25" ]
+                }
+            ]
         }
     },
     "Erebus Armor": {
@@ -3217,7 +3220,7 @@
             "effectImages": [
                 {
                     "id": "Condition",
-                    "args": [ "Sleep", "100" ]
+                    "args": [ "Sleep", "15" ]
                 }
             ]
         }
@@ -3498,7 +3501,7 @@
         "IsEquippable": true,
         "IsArtifact": true,
         "AddStatsOnEquip": {
-            "Def": 24
+            "Def": 22
         },
         "AddElStatsOnEquip": {
             "VenusRes": 15,
@@ -3510,7 +3513,7 @@
     "Hover Greave": {
         "Name": "Hover Greave",
         "Price": 4500,
-        "Icon": ":Hover_Greave:",
+        "Icon": "<:Hover_Greave:581970059962875932>",
         "ItemType": "Greave",
         "IsEquippable": true,
         "IsArtifact": true,
@@ -3606,7 +3609,7 @@
             "effectImages": [
                 {
                     "id": "Condition",
-                    "args": [ "Delusion", "100" ]
+                    "args": [ "Curse", "10" ]
                 }
             ]
         }
@@ -3671,7 +3674,8 @@
             "Def": 31
         },
         "AddElStatsOnEquip": {
-            "MercuryAtk": 20
+            "MercuryAtk": 30,
+            "MarsAtk": -10
         }
     },
     "Floating Hat": {
@@ -3700,7 +3704,8 @@
             "Def": 33
         },
         "AddElStatsOnEquip": {
-            "MarsAtk": 25
+            "MarsAtk": 30,
+            "MercuryAtk: -10
         }
     },
     "Crown of Glory": {
@@ -3729,8 +3734,8 @@
         "Unleash": {
             "effectImages": [
                 {
-                    "id": "Condition",
-                    "args": [ "Delusion", "30" ]
+                    "id": "ChanceToOHKO",
+                    "args": [ "5" ]
                 }
             ]
         }
@@ -3907,7 +3912,7 @@
     "Zol Tiara": {
         "Name": "Zol Tiara",
         "Price": 6000,
-        "Icon": ":Zol_Tiara:",
+        "Icon": "<:Zol_Tiara:581971650573107231>",
         "ItemType": "Circlet",
         "IsEquippable": true,
         "IsArtifact": true,
@@ -4176,7 +4181,7 @@
             "effectImages": [
                 {
                     "id": "Condition",
-                    "args": [ "Delusion", "30" ]
+                    "args": [ "Haunt", "10" ]
                 }
             ]
         }
@@ -4286,6 +4291,20 @@
         "AddElStatsOnEquip": {
             "JupiterAtk": 10,
             "MarsAtk": 10
+        }
+    },
+    "Air Bangle": {
+        "Name": "Air Bangle",
+        "Price": 6000,
+        "Icon": "<:Air_Bangle:581972768422363137>",
+        "ItemType": "Bracelet",
+        "IsArtifact": true,
+        "IsEquippable": true,
+        "AddStatsOnEquip": {
+            "Def": 39
+        },
+        "AddElStatsOnEquip": {
+            "JupiterAtk": 30
         }
     },
     "Battle Gloves": {
@@ -4571,7 +4590,7 @@
             "effectImages": [
                 {
                     "id": "Condition",
-                    "args": [ "Delusion", "30" ]
+                    "args": [ "Delusion", "25" ]
                 }
             ]
         }
@@ -4766,7 +4785,7 @@
             "effectImages": [
                 {
                     "id": "HPDrain",
-                    "args": [ "50" ]
+                    "args": [ "50", "20" ]
                 }
             ]
         }
@@ -4783,7 +4802,7 @@
             "effectImages": [
                 {
                     "id": "HPDrain",
-                    "args": [ "60", "10" ]
+                    "args": [ "75", "15" ]
                 }
             ]
         }
@@ -4798,6 +4817,14 @@
         "AddElStatsOnEquip": {
             "MercuryAtk": 30,
             "MercuryRes": 40
+        },
+        "Unleash": {
+            "effectImages": [
+                {
+                    "id": "HPDrain",
+                    "args": [ "33", "10" ]
+                }
+            ]
         }
     },
     "Sleep Ring": {
@@ -4812,7 +4839,7 @@
             "effectImages": [
                 {
                     "id": "Condition",
-                    "args": [ "Sleep", "30" ]
+                    "args": [ "Sleep", "15" ]
                 }
             ]
         }

--- a/IodemBot/Resources/items.json
+++ b/IodemBot/Resources/items.json
@@ -702,7 +702,7 @@
             "EffectImages": [
                 {
                     "Id": "AddDamage",
-                    "args": [ "62" ]
+                    "args": [ "26" ]
                 },
                 {
                     "id": "HPDrain",
@@ -2941,15 +2941,17 @@
         "IsEquippable": true,
         "IsArtifact": true,
         "AddStatsOnEquip": {
-            "Def": 38,
-            "MaxPP": 12
+            "Def": 38
+        },
+        "AddElStatsOnEquip": {
+            "VenusRes": 20
         },
         "GrantsUnleash": true,
         "Unleash": {
             "effectImages": [
                 {
                     "id": "Condition",
-                    "args": [ "Delusion", "25" ]
+                    "args": [ "Delusion", "30" ]
                 }
             ]
         }
@@ -3502,7 +3504,12 @@
         "IsArtifact": true,
         "AddStatsOnEquip": {
             "Def": 22
-        }
+        },
+        "AddElStatsOnEquip": {
+            "VenusAtk": 5,
+            "VenusRes": 15,
+            "MarsRes": -10
+        },
     },
     "Hover Greave": {
         "Name": "Hover Greave",
@@ -4779,7 +4786,7 @@
             "effectImages": [
                 {
                     "id": "HPDrain",
-                    "args": [ "50", "20" ]
+                    "args": [ "40", "20" ]
                 }
             ]
         }
@@ -4796,7 +4803,7 @@
             "effectImages": [
                 {
                     "id": "HPDrain",
-                    "args": [ "75", "15" ]
+                    "args": [ "60", "15" ]
                 }
             ]
         }
@@ -4816,7 +4823,7 @@
             "effectImages": [
                 {
                     "id": "HPDrain",
-                    "args": [ "33", "10" ]
+                    "args": [ "10", "20" ]
                 }
             ]
         }


### PR DESCRIPTION
Added the Zol Gear sprites & the Air Bangle that was missing.
Updated the emoji numbers for the Fire Brand, Verdant Sword and Sword of Dusk.

Corrected the values/effects of a bunch of items:
Alastor's Hood: 5% chance to add Condemn to an Unleash.
Prophet's Hat: 10% chance to add Curse to an Unleash.
Bone Armlet: 10% chance to add Haunt to an Unleash.
Sleep Ring: 15% chance to add Sleep to an Unleash.
Floral Dress: 15% chance to add Sleep to an Unleash.
Stardust Ring: 30% chance to add Bind to an Unleash.
Glittering Tiara: 25% chance to add Delude to an Unleash.
Mirrored Shield: 25% chance to add Delude to an Unleash.
Phantasmal Mail: 30% chance to add Delude to an Unleash.
Rainbow Ring: 40% chance to add Delude to an Unleash.

Updated the Hiotoko/Otafuku Masks:
Hiotoko Mask: +30 Mars Power, -10 Mercury Power.
Otafuku Mask: +30 Mercury Power, -10 Mars Power.

Updated Clotho's Distaff:
HPDrain: 30% chance to activate.
PPDrain: 30% chance to activate.

Other updates to the Phantasmal Mail:
Suppressed the MaxPP, VenusAtk, JupiterAtk and Jupiter Res.
Changed the VenusRes from 25 to 20.

Updates to the Silver Greaves:
Corrected the Def, from 24 to 22.
Changed the VenusAtk from 15 to 5.
Suppressed the VenusAtk and JupiterAtk.

Updates to the Aroma, Spirit and Heirloom Rings HPDrains:
Aroma: 40% HPDrain, 20% chance to activate.
Spirit: 60% HPDrain, 15% chance to activate.
Heirloom: 10% HPDrain, 20% chance to activate.