### PR TITLE
Update items.json

### DIFF
--- a/IodemBot/Resources/items.json
+++ b/IodemBot/Resources/items.json
@@ -4473,7 +4473,7 @@
     "Spirit Gauntlets": {
         "Name": "Spirit Gauntlets",
         "Price": 7200,
-        "Icon": "<:Spirit_Gloves_2:569854900192804864>",
+        "Icon": "<:Spirit_Gauntlets:587426621062119454>",
         "ItemType": "Glove",
         "IsArtifact": true,
         "IsEquippable": true,


### PR DESCRIPTION
Changed the "Spirit Gauntlets" icon's name to go with their new name.
(Their original name being "Spirit Gloves", but a different item with the same name exists in TBS, we changed it to avoid confusion)